### PR TITLE
Change anime-sama.fr to anime-sama.org

### DIFF
--- a/AnimeSama/src/main/kotlin/com/ycngmn/AnimesamaProvider.kt
+++ b/AnimeSama/src/main/kotlin/com/ycngmn/AnimesamaProvider.kt
@@ -26,7 +26,7 @@ import org.jsoup.nodes.Element
 
 class AnimesamaProvider : MainAPI() {
 
-    override var mainUrl = "https://anime-sama.fr"
+    override var mainUrl = "https://anime-sama.org"
     override var name = "Anime-sama"
     override val supportedTypes = setOf(
         TvType.Anime,
@@ -234,7 +234,7 @@ class AnimesamaProvider : MainAPI() {
      * @param streamPage The AnimeSama URL to scrape from.
      * Example:
      * ```
-     * https://anime-sama.fr/catalogue/anime-name/saison0/vostfr/
+     * https://anime-sama.org/catalogue/anime-name/saison0/vostfr/
      * ```
      * @return A map containing pairs of sources and their corresponding lists of stream links,
      *         or an empty list if no match is found.


### PR DESCRIPTION
Hi,
anime-sama changed its domain name from .fr to .org.
